### PR TITLE
Add workflow instances fetch

### DIFF
--- a/ste-btp-cm-ui/public/xs-app.json
+++ b/ste-btp-cm-ui/public/xs-app.json
@@ -13,6 +13,13 @@
       "target": "$1"
     },
     {
+      "authenticationType": "none",
+      "csrfProtection": false,
+      "source": "^/sap_process_automation_service/(.*)$",
+      "destination": "sap_process_automation_service",
+      "target": "$1"
+    },
+    {
       "source": "^(.*)$",
       "target": "$1",
       "service": "html5-apps-repo-rt",

--- a/ste-btp-cm-ui/src/api/index.js
+++ b/ste-btp-cm-ui/src/api/index.js
@@ -1,9 +1,16 @@
 import axios from "axios";
 
-const baseURL = "sthubsystem-qa/sap/opu/odata/sap/ZHR_GET_EMPLOYEE_DETAILS_CDS";
+const baseURL =
+  "sthubsystem-qa/sap/opu/odata/sap/ZHR_GET_EMPLOYEE_DETAILS_CDS";
 
 const instance = axios.create({
   baseURL
+});
+
+const workflowBaseURL = "sap_process_automation_service/v1";
+
+const workflowInstance = axios.create({
+  baseURL: workflowBaseURL
 });
 
 export const getTableData = async (params = { $top: 100, $skip: 0 }) => {
@@ -16,5 +23,10 @@ export const getTableData = async (params = { $top: 100, $skip: 0 }) => {
 
 export const getTableCount = async () => {
   const { data } = await instance.get("/ZHR_GET_EMPLOYEE_DETAILS/$count");
+  return data;
+};
+
+export const getWorkflowInstances = async () => {
+  const { data } = await workflowInstance.get("/workflow-instances");
   return data;
 };

--- a/ste-btp-cm-ui/src/pages/MasterPage.js
+++ b/ste-btp-cm-ui/src/pages/MasterPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Container, Box } from "@material-ui/core";
+import { Container, Box, Button } from "@material-ui/core";
 import { DataGrid } from "@material-ui/data-grid";
-import { getTableData, getTableCount } from "api";
+import { getTableData, getTableCount, getWorkflowInstances } from "api";
 
 const columns = [
   { field: "employeeID", headerName: "employeeID", width: 250 },
@@ -14,6 +14,7 @@ const PAGE_SIZE = 15;
 export default function MasterPage() {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [workflowInstances, setWorkflowInstances] = useState(null);
 
   // Number of rows which exist on the service
   const [rowCount, setRowCount] = useState(0);
@@ -46,6 +47,15 @@ export default function MasterPage() {
     loadData(false, page * PAGE_SIZE);
   };
 
+  const handleShowWorkflowInstances = async () => {
+    try {
+      const data = await getWorkflowInstances();
+      setWorkflowInstances(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   useEffect(() => {
     // when component mounted
     loadData(true);
@@ -53,6 +63,15 @@ export default function MasterPage() {
 
   return (
     <Container disableGutters>
+      <Box py={2}>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleShowWorkflowInstances}
+        >
+          Show workflow instances
+        </Button>
+      </Box>
       <Box height="80vh" py={5}>
         <DataGrid
           loading={loading}
@@ -64,6 +83,13 @@ export default function MasterPage() {
           onPageChange={handlePageChanged}
         />
       </Box>
+      {workflowInstances && (
+        <Box py={2}>
+          <pre style={{ whiteSpace: "pre-wrap" }}>
+            {JSON.stringify(workflowInstances, null, 2)}
+          </pre>
+        </Box>
+      )}
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- configure xs-app to route to `sap_process_automation_service`
- add axios client for the workflow service
- fetch workflow instances when clicking **Show workflow instances**

## Testing
- `npm test --prefix ste-btp-cm-ui --silent` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_6856f683f7ac832d970cc740f77c8258